### PR TITLE
Job retriggered even when Delayed::Worker.destroy_failed_jobs = false

### DIFF
--- a/lib/delayed_job_web/application/app.rb
+++ b/lib/delayed_job_web/application/app.rb
@@ -80,6 +80,7 @@ class DelayedJobWeb < Sinatra::Base
   get "/requeue/:id" do
     job = delayed_job.find(params[:id])
     job.run_at = Time.now
+    job.failed_at = nil
     job.save
     redirect back
   end


### PR DESCRIPTION
In delayed_job, the following flag can be used in delayed job to keep the task after a failure:
Delayed::Worker.destroy_failed_jobs = false

When this flag is set, delayed_job_web will not retry a job if it has failed. 

My fix is just to reset the failed_at to nil when retrying a job. Works for fine for me, but tell me if you see any improvements. 
