### PR TITLE
Fix relatizing future dates.

### DIFF
--- a/lib/delayed_job_web/application/public/javascripts/jquery.relatize_date.js
+++ b/lib/delayed_job_web/application/public/javascripts/jquery.relatize_date.js
@@ -28,7 +28,7 @@
       var day = date.getDay(), month = date.getMonth();
       var hours = date.getHours(), minutes = date.getMinutes();
 
-      var pad = function(num) { 
+      var pad = function(num) {
         var string = num.toString(10);
         return new Array((2 - string.length) + 1).join('0') + string
       };
@@ -53,11 +53,11 @@
         }
       })
     },
-  
+
     timeAgoInWords: function(targetDate, includeTime) {
       return $r.distanceOfTimeInWords(targetDate, new Date(), includeTime);
     },
-  
+
     /**
      * Return the distance of time in words between two Date's
      * Example: '5 days ago', 'about an hour ago'
@@ -67,7 +67,30 @@
      */
     distanceOfTimeInWords: function(fromTime, toTime, includeTime) {
       var delta = parseInt((toTime.getTime() - fromTime.getTime()) / 1000);
-      if (delta < 60) {
+      if (delta < (-(48*60*60) - 1)) {
+          var daysfrom = parseInt(Math.abs(delta / 86400));
+          if (daysfrom > 5) {
+              var fmt = '%B %d, %Y';
+              if (includeTime) fmt += ' %I:%M %p';
+              return $r.strftime(fromTime, fmt);
+          } else {
+              return daysfrom + " days from now";
+          }
+      } else if (delta < -(48*60*60)) {
+          return '1 day from now';
+      } else if (delta < -(24*60*60)) {
+          return 'about ' + parseInt(Math.abs(delta / 3600)).toString() +
+              ' hours from now';
+      } else if (delta < -(120*60)) {
+          return 'about an hour from now';
+      } else if (delta < -(45*60)) {
+          return parseInt(Math.abs(delta / 60)).toString()
+              + ' minutes from now';
+      } else if (delta < -60) {
+          return 'about a minute from now';
+      } else if (delta < 0) {
+          return 'less than a minute from now';
+      } else if (delta < 60) {
           return 'less than a minute ago';
       } else if (delta < 120) {
           return 'about a minute ago';


### PR DESCRIPTION
The jquery.relatize_date.js library didn't deal with dates in the future; this was a problem for the run_at field, since that could be scheduled to be a while from now.

I've patched and submitted a pull request to the upstream library, but it seems kinda dead, so I'm also submitting this pull request so that your app, at least, will show correct future relative dates.
