### PR TITLE
Fix haml dependency for newer rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
   gem "sinatra", '>= 0.9.2'
-  gem "haml", '>= 3.1.3'
+  gem "haml", '> 3.1'
   gem 'activerecord', '> 3.0.0'
   gem 'delayed_job', '> 2.0.3'
   gem 'rdoc'

--- a/delayed_job_web.gemspec
+++ b/delayed_job_web.gemspec
@@ -58,7 +58,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<sinatra>, [">= 0.9.2"])
-      s.add_runtime_dependency(%q<haml>, [">= 3.1.3"])
+      s.add_runtime_dependency(%q<haml>, ["> 3.1"])
       s.add_runtime_dependency(%q<activerecord>, ["> 3.0.0"])
       s.add_runtime_dependency(%q<delayed_job>, ["> 2.0.3"])
       s.add_runtime_dependency(%q<rdoc>, [">= 0"])
@@ -69,7 +69,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<rack-test>, [">= 0"])
     else
       s.add_dependency(%q<sinatra>, [">= 0.9.2"])
-      s.add_dependency(%q<haml>, [">= 3.1.3"])
+      s.add_dependency(%q<haml>, ["> 3.1"])
       s.add_dependency(%q<activerecord>, ["> 3.0.0"])
       s.add_dependency(%q<delayed_job>, ["> 2.0.3"])
       s.add_dependency(%q<rdoc>, [">= 0"])


### PR DESCRIPTION
This dep probably isn't very version-sensitive, opening it up a bit.
