### PR TITLE
Escape any html in job.handler or job.last_error

### DIFF
--- a/lib/delayed_job_web/application/views/job.haml
+++ b/lib/delayed_job_web/application/views/job.haml
@@ -17,15 +17,15 @@
       %dd= job.queue
     %dt Handler
     %dd
-      %pre= job.handler
+      %pre&= job.handler
     - if job.last_error
       %dt Last Error
       %dd
         %div.backtrace
-          %pre= job.last_error[0..100] + '...'
+          %pre&= job.last_error[0..100] + '...'
         %a{:href => '#', :class => 'backtrace'} Toggle full message
         %div.backtrace.full.hide
-          %pre= job.last_error
+          %pre&= job.last_error
     - if job.run_at
       %dt Run At
       %dd.time= job.run_at.rfc822


### PR DESCRIPTION
I have jobs with HTML in them, i.e. HTML emails, and they were getting rendered.

This fix escapes any HTML in either the Job's `handler` or `last_error` attribute
