### PR TITLE
Adding a new feature - Reload Job

### DIFF
--- a/lib/delayed_job_web/application/app.rb
+++ b/lib/delayed_job_web/application/app.rb
@@ -83,6 +83,12 @@ class DelayedJobWeb < Sinatra::Base
     redirect back
   end
 
+  get "/reload/:id" do
+    job = delayed_job.find(params[:id])
+    job.update_attributes(:run_at => Time.now, :failed_at => nil, :locked_by => nil, :locked_at => nil, :last_error => nil, :attempts => 0)
+    redirect back
+  end
+
   post "/failed/clear" do
     delayed_job.destroy_all(delayed_job_sql(:failed))
     redirect u('failed')

--- a/lib/delayed_job_web/application/views/job.haml
+++ b/lib/delayed_job_web/application/views/job.haml
@@ -8,6 +8,8 @@
         %a{:rel => 'retry', :href => u("requeue/#{job.id}")}Retry
         or
         %a{:rel => 'remove', :href => u("remove/#{job.id}")}Remove
+        or
+        %a{:rel => 'reload_job', :href => u("reload/#{job.id}")}Reload Job
     %dt Priority
     %dd= job.priority
     %dt Attempts


### PR DESCRIPTION
There have been scenarios, where my delayed jobs processes get killed, but the killed process had locked one of the dj entries. I would like to reload them via the delayed_job_web UI. So, I have written a small patch, which will reset the locked_by, locked_at, failed_at, :last_error, :attempts
