### PR TITLE
Tested with Rails 4 and ruby 2.0.0p353

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
+  gem "tilt", "1.4.1"
   gem "sinatra", '>= 0.9.2'
   gem "haml", '>= 3.1.3'
   gem 'activerecord', '> 3.0.0'

--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@ delayed_job_web
 ===============
 
 A [resque][0] inspired (read: stolen) interface for delayed_job.
-This gem is written to work with rails 3 applications using
+This gem is written to work with rails 3 and 4 applications using
 activerecord.
 
 Some features:
@@ -12,7 +12,7 @@ Some features:
 * Remove a failed job, or easily remove all failed jobs.
 * Watch delayed_job operation with live ajax polling.
 
-Quick Start For Rails 3 Applications
+Quick Start For Rails 3 and 4 Applications
 ------------------------------------
 
 Add the dependency to your Gemfile
@@ -30,7 +30,7 @@ bundle
 Add a route to your application for accessing the interface
 
 ```ruby
-match "/delayed_job" => DelayedJobWeb, :anchor => false
+get "/delayed_job" => DelayedJobWeb, :anchor => false
 ```
 
 You probably want to password protect the interface, an easy way is to add something like this your config.ru file
@@ -43,12 +43,12 @@ if Rails.env.production?
 end
 ```
 
+`delayed_job_web` runs as a Sinatra application within the rails application. Visit it at `/delayed_job_web`.
+
 The Interface - Yea, a ripoff of resque-web
 ------------------------------------
 
 ![Screen shot](http://dl.dropbox.com/u/1506097/Screenshots/delayed_job_web_1.png)
-
-![Screen shot](http://dl.dropbox.com/u/1506097/Screenshots/delayed_job_web_2.png)
 
 
 Author


### PR DESCRIPTION
Update tilt version (roll it back) so that tests
pass locally. (Works around uninitialized constant Tilt::CompileSite)

Readme updates: remove dead link, note that it works
with Rails 4 as well, and that it runs as a sinatra
app.
