### PR TITLE
According to a comment from tardate, adding a post

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,10 +27,11 @@ Install it...
 bundle
 ```
 
-Add a route to your application for accessing the interface
+Add the following route to your application for accessing the interface,
+and retrying failed jobs.
 
 ```ruby
-get "/delayed_job" => DelayedJobWeb, :anchor => false
+match "/delayed_job" => DelayedJobWeb, :anchor => false, via: [:get, :post]
 ```
 
 You probably want to password protect the interface, an easy way is to add something like this your config.ru file


### PR DESCRIPTION
route resolves the issue with "retry all failed jobs".

This change adds that route to the readme.

Comment:
https://github.com/ejschmitt/delayed_job_web/issues/33#issuecomment-32753527
