### PR TITLE
Fix queues param SQL injection

### DIFF
--- a/test/test_delayed_job_web.rb
+++ b/test/test_delayed_job_web.rb
@@ -26,6 +26,10 @@ class Delayed::Job
   def self.count(*args)
     0
   end
+
+  def self.order(*args)
+    DelayedJobFake.new
+  end
 end
 
 class TestDelayedJobWeb < Test::Unit::TestCase


### PR DESCRIPTION
Currently the `@queues` variable is populated from the params, and is then used to create a SQL string that is passed directly to the database. This allows you to execute arbitrary SQL statements from the query string.

This changes the SQL query generation to use standard `ActiveRecord::Base#where` methods, which are built to handle such things.
