### PR TITLE
Change destructive actions from GET to POST

### DIFF
--- a/lib/delayed_job_web/application/app.rb
+++ b/lib/delayed_job_web/application/app.rb
@@ -76,18 +76,18 @@ class DelayedJobWeb < Sinatra::Base
     end
   end
 
-  get "/remove/:id" do
+  post "/remove/:id" do
     delayed_job.find(params[:id]).delete
     redirect back
   end
 
-  get "/requeue/:id" do
+  post "/requeue/:id" do
     job = delayed_job.find(params[:id])
     job.update_attributes(:run_at => Time.now, :failed_at => nil)
     redirect back
   end
 
-  get "/reload/:id" do
+  post "/reload/:id" do
     job = delayed_job.find(params[:id])
     job.update_attributes(:run_at => Time.now, :failed_at => nil, :locked_by => nil, :locked_at => nil, :last_error => nil, :attempts => 0)
     redirect back

--- a/lib/delayed_job_web/application/public/stylesheets/style.css
+++ b/lib/delayed_job_web/application/public/stylesheets/style.css
@@ -75,6 +75,7 @@ pre { font-family:Courier New; line-height:1.4em; }
 #main ul.job li dl dd .retried .remove { display:none; margin-top: 8px; }
 #main ul.job li.hover dl dd .retried .remove { display:block; }
 #main ul.job li dl dd .controls { display:none; float:right; }
+#main ul.job li dl dd .controls form { display: inline; }
 #main ul.job li.hover dl dd .controls { display:block; }
 #main ul.job li dl dd code, #main ul.failed li dl dd pre { font-family:Monaco, "Courier New", monospace; font-size:90%; white-space: pre-wrap;}
 #main ul.job li dl dd.error a {font-family:Monaco, "Courier New", monospace; font-size:90%; }
@@ -84,6 +85,6 @@ pre { font-family:Courier New; line-height:1.4em; }
 #main p.pagination a.less { float:left;}
 #main p.pagination a.more { float:right;}
 
-#main form {float:right; margin-top:-10px;margin-left:10px;}
+#main .header-queues {float:right; margin-top:-10px;margin-left:10px;}
 
 #main .time a.toggle_format {text-decoration:none;}

--- a/lib/delayed_job_web/application/views/job.erb
+++ b/lib/delayed_job_web/application/views/job.erb
@@ -5,11 +5,11 @@
       <a name="<%= job.id %>"></a>
       <a href="#<%= job.id %>"><%= job.id %></a>
       <div class="controls">
-        <a href="<%= u("requeue/#{job.id}") %>" rel="retry">Retry</a>
+        <form action="<%= u("requeue/#{job.id}") %>" method="post"><input type="submit" value="Retry"></input></form>
         or
-        <a href="<%= u("remove/#{job.id}") %>" rel="remove">Remove</a>
+        <form action="<%= u("remove/#{job.id}") %>" method="post"><input type="submit" value="Remove"></input></form>
         or
-        <a href="<%= u("reload/#{job.id}") %>" rel="reload_job">Reload Job</a>
+        <form action="<%= u("reload/#{job.id}") %>" method="post"><input type="submit" value="Reload"></input></form>
       </div>
     </dd>
     <dt>Priority</dt>

--- a/lib/delayed_job_web/application/views/layout.erb
+++ b/lib/delayed_job_web/application/views/layout.erb
@@ -16,7 +16,7 @@
           </li>
         <% end %>
         <li>
-          <form method="get" action="" style="display:inline; width: 100%;">
+          <form method="get" class="header-queues" action="" style="display:inline; width: 100%;">
             <input name="queues" type="text" value="<%= @queues.join(", ") %>" style="width: 300px;" placeholder="Filter jobs by queue name (e.g. queue1, queue2)" />
             <input type="submit" value="Filter" />
           </form>


### PR DESCRIPTION
It's possible to delete delayed jobs from the database using GET requests. This would allow someone, using just an image tag, to delete arbitrary jobs from the database.

This changes those GET actions to a POST, which partially mitigates the problem. All full fix would also be to require CSRF a token along with the POST request.
