### PR TITLE
Prevent XSS by escaping potential HTML

### DIFF
--- a/lib/delayed_job_web/application/app.rb
+++ b/lib/delayed_job_web/application/app.rb
@@ -30,7 +30,12 @@ class DelayedJobWeb < Sinatra::Base
     url += "?queues=#{@queues.join(",")}" unless @queues.empty?
     url
   end
- alias_method :u, :url_path
+
+  alias_method :u, :url_path
+
+  def h(text)
+    Rack::Utils.escape_html(text)
+  end
 
   def path_prefix
     request.env['SCRIPT_NAME']

--- a/lib/delayed_job_web/application/views/error.erb
+++ b/lib/delayed_job_web/application/views/error.erb
@@ -1,2 +1,2 @@
 <h1>Error</h1>
-<p><%= @message %></p>
+<p><%=h @message %></p>

--- a/lib/delayed_job_web/application/views/job.erb
+++ b/lib/delayed_job_web/application/views/job.erb
@@ -3,7 +3,7 @@
     <dt>ID</dt>
     <dd>
       <a name="<%= job.id %>"></a>
-      <a href="#<%= job.id %>"><%= job.id %></a>
+      <a href="#<%= job.id %>"><%=h job.id %></a>
       <div class="controls">
         <form action="<%= u("requeue/#{job.id}") %>" method="post"><input type="submit" value="Retry"></input></form>
         or
@@ -13,49 +13,52 @@
       </div>
     </dd>
     <dt>Priority</dt>
-    <dd><%= job.priority %></dd>
+    <dd><%=h job.priority %></dd>
     <dt>Attempts</dt>
-    <dd><%= job.attempts %></dd>
+    <dd><%=h job.attempts %></dd>
     <% if job.respond_to?(:queue) && job.queue %>
       <dt>Queue</dt>
-      <dd><%= job.queue %></dd>
+      <dd><%=h job.queue %></dd>
     <% end %>
     <dt>Handler</dt>
     <dd>
-    <pre><%= job.handler %></pre>
+    <pre><%=h job.handler %></pre>
     </dd>
     <% if job.last_error %>
       <dt>Last Error</dt>
       <dd>
         <div class="backtrace">
-          <pre><%= job.last_error[0..100] + '...' %></pre>
+          <pre><%=h job.last_error[0..100] + '...' %></pre>
         </div>
         <a class="backtrace" href="#">Toggle full message</a>
         <div class="backtrace full hide">
-          <pre><%= job.last_error %></pre>
+          <pre><%=h job.last_error %></pre>
         </div>
       </dd>
     <% end %>
     <% if job.run_at %>
       <dt>Run At</dt>
       <dd class="time">
-        <%= job.run_at.rfc822 %>
+        <%=h job.run_at.rfc822 %>
       </dd>
     <% end %>
     <% if job.locked_at %>
       <dt>Locked At</dt>
       <dd class="time">
-        <%= job.locked_at.rfc822 %>
+        <%=h job.locked_at.rfc822 %>
       </dd>
     <% end %>
     <% if job.locked_by %>
       <dt>Locked By</dt>
       <dd>
-        <%= job.locked_by %>
+        <%=h job.locked_by %>
       </dd>
     <% end %>
     <% if job.failed_at %>
       <dt>Failed At</dt>
+      <dd>
+        <%=h job.failed_at %>
+      </dd>
     <% end %>
   </dl>
 </li>

--- a/lib/delayed_job_web/application/views/layout.erb
+++ b/lib/delayed_job_web/application/views/layout.erb
@@ -11,13 +11,13 @@
         <% tabs.each do |tab| %>
           <li class="<%= request.path_info == tab[:path] ? 'current' : '' %>">
             <a class="tab" href="<%= u(tab[:path]) %>">
-              <%= tab[:name] %>
+              <%=h tab[:name] %>
             </a>
           </li>
         <% end %>
         <li>
           <form method="get" class="header-queues" action="" style="display:inline; width: 100%;">
-            <input name="queues" type="text" value="<%= @queues.join(", ") %>" style="width: 300px;" placeholder="Filter jobs by queue name (e.g. queue1, queue2)" />
+            <input name="queues" type="text" value="<%=h @queues.join(", ") %>" style="width: 300px;" placeholder="Filter jobs by queue name (e.g. queue1, queue2)" />
             <input type="submit" value="Filter" />
           </form>
         </li>
@@ -30,7 +30,7 @@
       <p>
         Powered by
         <a href="https://github.com/collectiveidea/delayed_job">delayed_job</a>
-        &
+        &amp;
         <a href="https://github.com/ejschmitt/delayed_job_web">delayed_job_web</a>
       </p>
     </div>

--- a/lib/delayed_job_web/application/views/stats.erb
+++ b/lib/delayed_job_web/application/views/stats.erb
@@ -5,7 +5,7 @@
       environment
     </th>
     <th>
-      <%= Sinatra::Application.environment.to_s %>
+      <%=h Sinatra::Application.environment.to_s %>
     </th>
   </tr>
   <tr>


### PR DESCRIPTION
Escapes potential HTML content by adding a `h` helper method and using it in the views whenever text output from the DB is rendered into a view.

Closes #49
