### PR TITLE
Add CSRF protection to all form posts

### DIFF
--- a/delayed_job_web.gemspec
+++ b/delayed_job_web.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.summary = "Web interface for delayed_job"
 
-  s.add_runtime_dependency(%q<sinatra>, [">= 0.9.2"])
+  s.add_runtime_dependency(%q<sinatra>, [">= 1.4.4"])
   s.add_runtime_dependency(%q<activerecord>, ["> 3.0.0"])
   s.add_runtime_dependency(%q<delayed_job>, ["> 2.0.3"])
   s.add_development_dependency(%q<shoulda>, [">= 0"])

--- a/lib/delayed_job_web/application/views/failed.erb
+++ b/lib/delayed_job_web/application/views/failed.erb
@@ -1,9 +1,11 @@
 <h1>Failed Jobs</h1>
 <% if @jobs.any? %>
   <form action="<%= u('failed/clear') %>" method="POST">
+    <%= csrf_token_tag %>
     <input type="submit" value="Clear Failed Jobs"></input>
   </form>
   <form action="<%= u('requeue/all') %>" method="POST">
+    <%= csrf_token_tag %>
     <input type="submit" value="Retry Failed Jobs"></input>
   </form>
 <% end %>

--- a/lib/delayed_job_web/application/views/job.erb
+++ b/lib/delayed_job_web/application/views/job.erb
@@ -5,11 +5,11 @@
       <a name="<%= job.id %>"></a>
       <a href="#<%= job.id %>"><%=h job.id %></a>
       <div class="controls">
-        <form action="<%= u("requeue/#{job.id}") %>" method="post"><input type="submit" value="Retry"></input></form>
+        <form action="<%= u("requeue/#{job.id}") %>" method="post"><%= csrf_token_tag %><input type="submit" value="Retry"></input></form>
         or
-        <form action="<%= u("remove/#{job.id}") %>" method="post"><input type="submit" value="Remove"></input></form>
+        <form action="<%= u("remove/#{job.id}") %>" method="post"><%= csrf_token_tag %><input type="submit" value="Remove"></input></form>
         or
-        <form action="<%= u("reload/#{job.id}") %>" method="post"><input type="submit" value="Reload"></input></form>
+        <form action="<%= u("reload/#{job.id}") %>" method="post"><%= csrf_token_tag %><input type="submit" value="Reload"></input></form>
       </div>
     </dd>
     <dt>Priority</dt>

--- a/lib/delayed_job_web/application/views/pending.erb
+++ b/lib/delayed_job_web/application/views/pending.erb
@@ -1,6 +1,7 @@
 <h1>Pending</h1>
 <% if @jobs.any? %>
   <form action="<%= u('requeue/all') %>" method="POST">
+    <%= csrf_token_tag %>
     <input type="submit" value="Enqueue All Immediately"></input>
   </form>
 <% end %>


### PR DESCRIPTION
A cleaned up version of the CSRF protection that was originally included in #51.

This enables cookie-based sessions in the Sinatra app, but they're scoped to just the app using a unique cookie name.

Closes #54.
