### PR TITLE
Enable filtering on handler, last_error and queue

### DIFF
--- a/lib/delayed_job_web/application/views/failed.erb
+++ b/lib/delayed_job_web/application/views/failed.erb
@@ -2,10 +2,14 @@
 <% if @jobs.any? %>
   <form action="<%= u('failed/clear') %>" method="POST">
     <%= csrf_token_tag %>
+
+    <input name="filters" type="hidden" value="<%=h @filters.join(", ") %>" />
     <input type="submit" value="Clear Failed Jobs"></input>
   </form>
   <form action="<%= u('requeue/failed') %>" method="POST">
     <%= csrf_token_tag %>
+
+    <input name="filters" type="hidden" value="<%=h @filters.join(", ") %>" />
     <input type="submit" value="Retry Failed Jobs"></input>
   </form>
 <% end %>

--- a/lib/delayed_job_web/application/views/layout.erb
+++ b/lib/delayed_job_web/application/views/layout.erb
@@ -16,8 +16,8 @@
           </li>
         <% end %>
         <li>
-          <form method="get" class="header-queues" action="" style="display:inline; width: 100%;">
-            <input name="queues" type="text" value="<%=h @queues.join(", ") %>" style="width: 300px;" placeholder="Filter jobs by queue name (e.g. queue1, queue2)" />
+          <form method="get" class="header-filters" action="" style="display:inline; width: 100%;">
+            <input name="filters" type="text" value="<%=h @filters.join(", ") %>" style="width: 300px;" placeholder="Filter jobs by handler, last_error or queue" />
             <input type="submit" value="Filter" />
           </form>
         </li>

--- a/lib/delayed_job_web/application/views/next_more.erb
+++ b/lib/delayed_job_web/application/views/next_more.erb
@@ -1,5 +1,5 @@
 <% if start - per_page >= 0 || start + per_page <= total_size %>
-<% divider = @queues.empty? ? "?" : "&" %>
+<% divider = @filters.empty? ? "?" : "&" %>
   <p class="pagination">
     <% if start - per_page >= 0 %>
       <a class="less" href="<%= current_page %><%= divider %>start=<%= start - per_page %>">&laquo; less</a>

--- a/lib/delayed_job_web/application/views/overview.erb
+++ b/lib/delayed_job_web/application/views/overview.erb
@@ -14,7 +14,7 @@
       <a href="<%= u('/enqueued') %>">Enqueued Jobs</a>
     </td>
     <td>
-      <%= delayed_jobs(:enqueued, @queues).count %>
+      <%= delayed_jobs(:enqueued, @filters).count %>
     </td>
   </tr>
   <tr>
@@ -22,7 +22,7 @@
       <a href="<%= u('/working') %>">Working Jobs</a>
     </td>
     <td>
-      <%= delayed_jobs(:working, @queues).count %>
+      <%= delayed_jobs(:working, @filters).count %>
     </td>
   </tr>
   <tr>
@@ -30,15 +30,15 @@
       <a href="<%= u('/pending') %>">Pending Jobs</a>
     </td>
     <td>
-      <%= delayed_jobs(:pending, @queues).count %>
+      <%= delayed_jobs(:pending, @filters).count %>
     </td>
   </tr>
-  <tr class="<%= delayed_jobs(:failed, @queues).count > 0 ? 'failure' : '' %>">
+  <tr class="<%= delayed_jobs(:failed, @filters).count > 0 ? 'failure' : '' %>">
     <td class="status">
       <a href="<%= u('/failed') %>">Failed Jobs</a>
     </td>
     <td>
-      <%= delayed_jobs(:failed, @queues).count %>
+      <%= delayed_jobs(:failed, @filters).count %>
     </td>
   </tr>
 </table>

--- a/lib/delayed_job_web/application/views/stats.erb
+++ b/lib/delayed_job_web/application/views/stats.erb
@@ -13,7 +13,7 @@
       failed
     </th>
     <th>
-      <%= delayed_jobs(:failed, @queues).count %>
+      <%= delayed_jobs(:failed, @filters).count %>
     </th>
   </tr>
   <tr>
@@ -21,7 +21,7 @@
       pending
     </th>
     <th>
-      <%= delayed_jobs(:pending, @queues).count %>
+      <%= delayed_jobs(:pending, @filters).count %>
     </th>
   </tr>
   <tr>
@@ -29,7 +29,7 @@
       working
     </th>
     <th>
-      <%= delayed_jobs(:working, @queues).count %>
+      <%= delayed_jobs(:working, @filters).count %>
     </th>
   </tr>
 </table>


### PR DESCRIPTION
This PR enables users to search jobs based on handler, last_error and queue. I also renamed @queues to @filters for the sake of clarity.
