### PR TITLE
Enqueue All Immediately button in pending tab enqueues pending jobs, not failed

### DIFF
--- a/lib/delayed_job_web/application/app.rb
+++ b/lib/delayed_job_web/application/app.rb
@@ -115,9 +115,11 @@ class DelayedJobWeb < Sinatra::Base
     redirect back
   end
 
-  post "/requeue/all" do
-    delayed_jobs(:failed, @queues).update_all(:run_at => Time.now, :failed_at => nil)
-    redirect back
+  %w(pending failed).each do |page|
+    post "/requeue/#{page}" do
+      delayed_jobs(page.to_sym, @queues).update_all(:run_at => Time.now, :failed_at => nil)
+      redirect back
+    end
   end
 
   post "/requeue/:id" do

--- a/lib/delayed_job_web/application/views/failed.erb
+++ b/lib/delayed_job_web/application/views/failed.erb
@@ -4,7 +4,7 @@
     <%= csrf_token_tag %>
     <input type="submit" value="Clear Failed Jobs"></input>
   </form>
-  <form action="<%= u('requeue/all') %>" method="POST">
+  <form action="<%= u('requeue/failed') %>" method="POST">
     <%= csrf_token_tag %>
     <input type="submit" value="Retry Failed Jobs"></input>
   </form>

--- a/lib/delayed_job_web/application/views/pending.erb
+++ b/lib/delayed_job_web/application/views/pending.erb
@@ -1,6 +1,6 @@
 <h1>Pending</h1>
 <% if @jobs.any? %>
-  <form action="<%= u('requeue/all') %>" method="POST">
+  <form action="<%= u('requeue/pending') %>" method="POST">
     <%= csrf_token_tag %>
     <input type="submit" value="Enqueue All Immediately"></input>
   </form>


### PR DESCRIPTION
Fixes issue #74 

Split `post "requeue/all"` into 2 routes, `post "requeue/failed"` and  `post "requeue/pending"` so that the Enqueue All Immediately button only requeue job that are in the pending tab