### PR TITLE
Fix run at "relatize_date" inaccuracy

### DIFF
--- a/lib/delayed_job_web/application/public/javascripts/jquery.relatize_date.js
+++ b/lib/delayed_job_web/application/public/javascripts/jquery.relatize_date.js
@@ -77,17 +77,17 @@
               return daysfrom + " days from now";
           }
       } else if (delta < -(48*60*60)) {
-          return '1 day from now';
+          return '2 days from now';
       } else if (delta < -(24*60*60)) {
+          return '1 day from now';
+      } else if (delta < -(120*60)) {
           return 'about ' + parseInt(Math.abs(delta / 3600)).toString() +
               ' hours from now';
-      } else if (delta < -(120*60)) {
-          return 'about an hour from now';
       } else if (delta < -(45*60)) {
+          return 'about an hour from now';
+      } else if (delta < -60) {
           return parseInt(Math.abs(delta / 60)).toString()
               + ' minutes from now';
-      } else if (delta < -60) {
-          return 'about a minute from now';
       } else if (delta < 0) {
           return 'less than a minute from now';
       } else if (delta < 60) {
@@ -102,7 +102,6 @@
           return 'about ' + (parseInt(delta / 3600)).toString() + ' hours ago';
       } else if (delta < (48*60*60)) {
           return '1 day ago';
-      } else {
         var days = (parseInt(delta / 86400)).toString();
         if (days > 5) {
           var fmt  = '%B %d, %Y'


### PR DESCRIPTION
Addresses issue #69
The run at time in word is not accurate, this fixes the minor logic issue in relatize_date script.
