### PR TITLE
Allow user to specify per_page

### DIFF
--- a/lib/delayed_job_web/application/app.rb
+++ b/lib/delayed_job_web/application/app.rb
@@ -38,7 +38,7 @@ class DelayedJobWeb < Sinatra::Base
   end
 
   def per_page
-    20
+    params[:per_page].to_i > 0 ? params[:per_page].to_i : 20
   end
 
   def url_path(*path_parts)


### PR DESCRIPTION
A user may want to view more than 20 jobs per page. This gives the user the option to set that in the URL params if they so choose (i.e. /delayed_job/enqueued?per_page=100)
