### PR TITLE
Adding a section for Heroku worker monitoring and zombie detection

### DIFF
--- a/lib/delayed_job_web/application/views/dynos.erb
+++ b/lib/delayed_job_web/application/views/dynos.erb
@@ -22,7 +22,7 @@
     </th>
   </tr>
 
-  <% heroku_dynos.select{|dyno| dyno["type"] != "web"}.each do |dyno| %>
+  <% HerokuPlatform.dynos.select{|dyno| dyno["type"] != "web"}.each do |dyno| %>
   <tr>
     <td>
       <%= dyno["name"] %>

--- a/lib/delayed_job_web/application/views/dynos.erb
+++ b/lib/delayed_job_web/application/views/dynos.erb
@@ -3,10 +3,16 @@
   <%= csrf_token_tag %>
   <input type="submit" value="Refresh"></input>
 </form>
-<table class="stats">
+<table>
   <tr>
-    <th class="status">
+    <th>
       name
+    </th>
+    <th>
+      jobs
+    </th>
+    <th>
+      age&nbsp;(hours)
     </th>
     <th>
       id
@@ -14,24 +20,26 @@
     <th>
       state
     </th>
-    <th>
-      age (hours)
-    </th>
   </tr>
 
-  <% heroku_dynos.each do |dyno| %>
+  <% heroku_dynos.select{|dyno| dyno["type"] != "web"}.each do |dyno| %>
   <tr>
     <td>
       <%= dyno["name"] %>
+    </td>
+    <td>
+      <a href='<%= u("/working?dyno_name=#{dyno['name']}&dyno_id=#{dyno['id']}") %>'>
+        <%= delayed_jobs(:working).locked_by_like(dyno["id"]).count %>
+      </a>
+    </td>
+    <td>
+      <%= ((Time.now - DateTime.iso8601(dyno["created_at"]))/60/60).round(1) %>
     </td>
     <td>
       <%= dyno["id"] %>
     </td>
     <td>
       <%= dyno["state"] %>
-    </td>
-    <td>
-      <%= ((Time.now - DateTime.iso8601(dyno["created_at"]))/60/60).round(1) %>
     </td>
   </tr>
   <% end %>

--- a/lib/delayed_job_web/application/views/dynos.erb
+++ b/lib/delayed_job_web/application/views/dynos.erb
@@ -1,0 +1,39 @@
+<h1>Heroku dynos</h1>
+<form action="<%= u('/refresh_heroku_dynos') %>" method="POST">
+  <%= csrf_token_tag %>
+  <input type="submit" value="Refresh"></input>
+</form>
+<table class="stats">
+  <tr>
+    <th class="status">
+      name
+    </th>
+    <th>
+      id
+    </th>
+    <th>
+      state
+    </th>
+    <th>
+      age (hours)
+    </th>
+  </tr>
+
+  <% heroku_dynos.each do |dyno| %>
+  <tr>
+    <td>
+      <%= dyno["name"] %>
+    </td>
+    <td>
+      <%= dyno["id"] %>
+    </td>
+    <td>
+      <%= dyno["state"] %>
+    </td>
+    <td>
+      <%= ((Time.now - DateTime.iso8601(dyno["created_at"]))/60/60).round(1) %>
+    </td>
+  </tr>
+  <% end %>
+
+</table>

--- a/lib/delayed_job_web/application/views/overview.erb
+++ b/lib/delayed_job_web/application/views/overview.erb
@@ -25,7 +25,7 @@
       <%= delayed_jobs(:working, @queues).count %>
     </td>
   </tr>
-  <% if monitor_zombies %>
+  <% if HerokuPlatform.monitor_zombies %>
   <tr>
     <td class="status">
       <a href="<%= u('/zombies') %>">Heroku Zombie Jobs</a>
@@ -53,7 +53,7 @@
   </tr>
 </table>
 
-<% if monitor_zombies %>
+<% if HerokuPlatform.monitor_zombies %>
 <%= partial :dynos %>
 <% end %>
 

--- a/lib/delayed_job_web/application/views/overview.erb
+++ b/lib/delayed_job_web/application/views/overview.erb
@@ -25,6 +25,16 @@
       <%= delayed_jobs(:working, @queues).count %>
     </td>
   </tr>
+  <% if monitor_zombies %>
+  <tr>
+    <td class="status">
+      <a href="<%= u('/zombies') %>">Heroku Zombie Jobs</a>
+    </td>
+    <td>
+      <%= delayed_jobs(:zombies, @queues).count %>
+    </td>
+  </tr>
+  <% end %>
   <tr>
     <td class="status">
       <a href="<%= u('/pending') %>">Pending Jobs</a>
@@ -42,4 +52,9 @@
     </td>
   </tr>
 </table>
+
+<% if monitor_zombies %>
+<%= partial :dynos %>
+<% end %>
+
 <%= poll %>

--- a/lib/delayed_job_web/application/views/stats.erb
+++ b/lib/delayed_job_web/application/views/stats.erb
@@ -32,5 +32,15 @@
       <%= delayed_jobs(:working, @queues).count %>
     </th>
   </tr>
+  <% if monitor_zombies %>
+  <tr>
+    <th class="status">
+      heroku zombies
+    </th>
+    <th>
+      <%= delayed_jobs(:zombies, @queues).count %>
+    </th>
+  </tr>
+  <% end %>
 </table>
 <%= poll %>

--- a/lib/delayed_job_web/application/views/stats.erb
+++ b/lib/delayed_job_web/application/views/stats.erb
@@ -32,7 +32,7 @@
       <%= delayed_jobs(:working, @queues).count %>
     </th>
   </tr>
-  <% if monitor_zombies %>
+  <% if HerokuPlatform.monitor_zombies %>
   <tr>
     <th class="status">
       heroku zombies

--- a/lib/delayed_job_web/application/views/working.erb
+++ b/lib/delayed_job_web/application/views/working.erb
@@ -1,4 +1,7 @@
 <h1>Working</h1>
+<% if @dyno_name %>
+  <h1>Dyno: <%= @dyno_name %></h1>
+<% end %>
 <p class="sub">
   The list below contains jobs currently being processed.
 </p>

--- a/lib/delayed_job_web/application/views/zombies.erb
+++ b/lib/delayed_job_web/application/views/zombies.erb
@@ -1,0 +1,21 @@
+<%= partial :dynos %>
+
+<h1>Heroku Zombies</h1>
+<% if @jobs.any? %>
+  <form action="<%= u('requeue/all') %>" method="POST">
+    <%= csrf_token_tag %>
+    <input type="submit" value="Enqueue All Immediately"></input>
+  </form>
+<% end %>
+<p class="sub">
+  The list below contains jobs currently being locked by zombie workers (workers that have been killed without unlocking their jobs)
+</p>
+<p class="sub">
+  <%= "Showing #{start} to #{start + per_page} of #{@all_jobs.count} zombie jobs." %>
+</p>
+<ul class="job">
+  <% @jobs.each do |job| %>
+    <%= partial :job, {:job => job} %>
+  <% end %>
+</ul>
+<%= partial :next_more, :start => start, :total_size => @all_jobs.count, :per_page => per_page %>

--- a/lib/delayed_job_web/application/views/zombies.erb
+++ b/lib/delayed_job_web/application/views/zombies.erb
@@ -2,7 +2,7 @@
 
 <h1>Heroku Zombies</h1>
 <% if @jobs.any? %>
-  <form action="<%= u('requeue/all') %>" method="POST">
+  <form action="<%= u('requeue/zombies') %>" method="POST">
     <%= csrf_token_tag %>
     <input type="submit" value="Enqueue All Immediately"></input>
   </form>


### PR DESCRIPTION
Adding a section to monitor heroku dynos in a table view.
Also sometimes when a heroku dyno dies and leaves the job locked, this PR will list those zombie jobs so that they can be requeued or cleared.
For the heroku integration to work, 2 environment variables need to be set:
`DJWEB_HEROKU_TOKEN` and `DJWEB_HEROKU_APP_NAME`
If any of these 2 are not found, the gem will work normally without heroku integration.