### PR TITLE
Adding information to the readme on how to authenticate with Devise

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -55,7 +55,7 @@ end
 
 ## Authenticating with Devise and Warden
 
-This can be accomplished in the routes.rb file using an `authenticated`. Note, do not use an `authenticate` block as this forces an authentication check and redirects can be screwy, [see here](http://excid3.com/blog/rails-tip-5-authenticated-root-and-dashboard-routes-with-devise/) for more information.
+This can be accomplished in the routes.rb file using an `authenticated` callback. Note, do not use an `authenticate` callback as this forces an authentication check and redirects can be screwy, [see here](http://excid3.com/blog/rails-tip-5-authenticated-root-and-dashboard-routes-with-devise/) for more information.
 
 A simple user check looks like this:
 

--- a/README.markdown
+++ b/README.markdown
@@ -52,6 +52,30 @@ end
 
 `delayed_job_web` runs as a Sinatra application within the rails application. Visit it at `/delayed_job`.
 
+
+## Authenticating with Devise and Warden
+
+This can be accomplished in the routes.rb file using an `authenticated`. Note, do not use an `authenticate` block as this forces an authentication check and redirects can be screwy, [see here](http://excid3.com/blog/rails-tip-5-authenticated-root-and-dashboard-routes-with-devise/) for more information.
+
+A simple user check looks like this:
+
+```ruby
+
+authenticated :user do
+  mount DelayedJobWeb, at: "/delayed_job"
+end
+
+```
+But you probably want to check for administrator permissions:
+
+```ruby
+
+authenticated :user, -> user { user.admin? }  do
+  mount DelayedJobWeb, at: "/delayed_job"
+end
+
+```
+
 ## Serving static assets
 
 If you mount the app on another route, you may encounter the CSS not working anymore. To work around this you can leverage a special HTTP header. Install it, activate it and configure it -- see below.


### PR DESCRIPTION
This is information gathered from various sources on how to implement device authentication for the delayed job routes.

This allows an authenticated devise user to access the delayed job interface, but not others.