### PR TITLE
Fix working count so that it does not show failed jobs

### DIFF
--- a/lib/delayed_job_web/application/app.rb
+++ b/lib/delayed_job_web/application/app.rb
@@ -167,7 +167,7 @@ class DelayedJobWeb < Sinatra::Base
     rel =
       case type
       when :working
-        rel.where('locked_at IS NOT NULL')
+        rel.where('locked_at IS NOT NULL AND failed_at IS NULL')
       when :failed
         rel.where('last_error IS NOT NULL')
       when :pending


### PR DESCRIPTION
When `destroy_failed_jobs = false` is set and the max attempts for a job is reached and it fails, the `failed_at` gets set. But since the `locked_at` and `locked_by` are not cleared ([by design](https://github.com/collectiveidea/delayed_job/issues/993)), it still shows as working.