### PR TITLE
Fix pending.erb view syntax errors (#96)

### DIFF
--- a/lib/delayed_job_web/application/views/pending.erb
+++ b/lib/delayed_job_web/application/views/pending.erb
@@ -1,11 +1,11 @@
 <h1>Pending</h1>
 <% if @jobs.any? %>
-  <% if @allow_requeue_pending -%>
+  <% if @allow_requeue_pending %>
     <form action="<%= u('requeue/pending') %>" method="POST">
       <%= csrf_token_tag %>
       <input type="submit" value="Enqueue All Immediately"></input>
     </form>
-  <% end -%>
+  <% end %>
 <% end %>
 <p class="sub">
   The list below contains jobs currently being processed.


### PR DESCRIPTION
This commit fixes syntax errors preventing the pending view from being
displayed. Changing the `-%>` in the ERB view to `%>` seems to do the
job.

Fixes: #96