### PR TITLE
Fix CVE-2017-12097

### DIFF
--- a/delayed_job_web.gemspec
+++ b/delayed_job_web.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
     "README.markdown"
   ]
 
-  gem.add_runtime_dependency "sinatra",      [">= 1.4.4"]
+  gem.add_runtime_dependency "sinatra",      [">= 2.0.1"]
   gem.add_runtime_dependency "activerecord", ["> 3.0.0"]
   gem.add_runtime_dependency "delayed_job",  ["> 2.0.3"]
 


### PR DESCRIPTION
From https://www.talosintelligence.com/vulnerability_reports/TALOS-2017-0449

An exploitable XSS vulnerability exists in the filter functionality of the
delayed_job_web rails gem version 1.4. A specially crafted URL can cause an
XSS flaw resulting in an attacker being able to execute arbitrary javascript
on the victim’s browser. An attacker can phish an authenticated user to
trigger this vulnerability.

The delayed_job_web gem allows users to filter output based on the query
string of the GET request. This looks similar to.

localhost:3000/delayed_job/overview?queues=">+<script>alert(1)<%2Fscript>

This URL can them be used to phish an authenticated user and execute arbitrary
javascript on their behalf. This vulnerability is caught by the built in XSS
protections of Safari and Chrome., however it is exploitable using Firefox.

Fixes https://github.com/ejschmitt/delayed_job_web/issues/101