### PR TITLE
Fix CVE-2018-7212

### DIFF
--- a/delayed_job_web.gemspec
+++ b/delayed_job_web.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name        = "delayed_job_web"
-  gem.version     = "1.4"
+  gem.version     = "1.4.1"
   gem.author      = "Erick Schmitt"
   gem.email       = "ejschmitt@gmail.com"
   gem.homepage    = "https://github.com/ejschmitt/delayed_job_web"
@@ -23,11 +23,11 @@ Gem::Specification.new do |gem|
     "README.markdown"
   ]
 
-  gem.add_runtime_dependency "sinatra",      [">= 1.4.4"]
+  gem.add_runtime_dependency "sinatra",      [">= 2.0.1"]
   gem.add_runtime_dependency "activerecord", ["> 3.0.0"]
   gem.add_runtime_dependency "delayed_job",  ["> 2.0.3"]
 
-  gem.add_development_dependency "minitest",  ["~> 4.2"]
+  gem.add_development_dependency "minitest",  ["~> 5.0"]
   gem.add_development_dependency "rack-test", ["~> 0.6"]
-  gem.add_development_dependency "rails",     ["~> 4.0"]
+  gem.add_development_dependency "rails",     ["~> 5.0"]
 end


### PR DESCRIPTION
An issue was discovered in `rack-protection/lib/rack/protection/path_traversal.rb` in Sinatra 2.x before 2.0.1 on Windows. Path traversal is possible via backslash characters.

https://nvd.nist.gov/vuln/detail/CVE-2018-7212.