### PR TITLE
Fixes #101: Add escape for CVE-2017-12097

### DIFF
--- a/lib/delayed_job_web/application/app.rb
+++ b/lib/delayed_job_web/application/app.rb
@@ -45,7 +45,7 @@ class DelayedJobWeb < Sinatra::Base
 
   def url_path(*path_parts)
     url = [ path_prefix, path_parts ].join("/").squeeze('/')
-    url += "?queues=#{@queues.join(",")}" unless @queues.empty?
+    url += "?queues=#{CGI.escape(@queues.join(","))}" unless @queues.empty?
     url
   end
 


### PR DESCRIPTION
Triggered by including HTML in the `queues` param which is then combined with an [A tag in raw HTML](https://github.com/ejschmitt/delayed_job_web/blob/master/lib/delayed_job_web/application/views/overview.erb#L14) via the `url_path` (alias `u`) helper. Fixed by adding a CGI escape to the helper.

https://nvd.nist.gov/vuln/detail/CVE-2017-12097