### PR TITLE
Safer fix for CVE-2018-7212

### DIFF
--- a/delayed_job_web.gemspec
+++ b/delayed_job_web.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   ]
 
   gem.add_runtime_dependency "sinatra",         [">= 1.4.4"]
-  gem.add_runtime_dependency "rack-protection", ["~> 1.5"]
+  gem.add_runtime_dependency "rack-protection", [">= 1.5.5"]
   gem.add_runtime_dependency "activerecord",    ["> 3.0.0"]
   gem.add_runtime_dependency "delayed_job",     ["> 2.0.3"]
 

--- a/delayed_job_web.gemspec
+++ b/delayed_job_web.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name        = "delayed_job_web"
-  gem.version     = "1.4.2"
+  gem.version     = "1.4.3"
   gem.author      = "Erick Schmitt"
   gem.email       = "ejschmitt@gmail.com"
   gem.homepage    = "https://github.com/ejschmitt/delayed_job_web"

--- a/delayed_job_web.gemspec
+++ b/delayed_job_web.gemspec
@@ -23,11 +23,11 @@ Gem::Specification.new do |gem|
     "README.markdown"
   ]
 
-  gem.add_runtime_dependency "sinatra",      [">= 2.0.1"]
-  gem.add_runtime_dependency "activerecord", ["> 3.0.0"]
-  gem.add_runtime_dependency "delayed_job",  ["> 2.0.3"]
+  gem.add_runtime_dependency "sinatra",         [">= 1.4.4"]
+  gem.add_runtime_dependency "activerecord",    ["> 3.0.0"]
+  gem.add_runtime_dependency "delayed_job",     ["> 2.0.3"]
 
-  gem.add_development_dependency "minitest",  ["~> 5.0"]
+  gem.add_development_dependency "minitest",  ["~> 4.2"]
   gem.add_development_dependency "rack-test", ["~> 0.6"]
-  gem.add_development_dependency "rails",     ["~> 5.0"]
+  gem.add_development_dependency "rails",     ["~> 4.0"]
 end

--- a/delayed_job_web.gemspec
+++ b/delayed_job_web.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |gem|
   ]
 
   gem.add_runtime_dependency "sinatra",         [">= 1.4.4"]
+  gem.add_runtime_dependency "rack-protection", ["~> 1.5"]
   gem.add_runtime_dependency "activerecord",    ["> 3.0.0"]
   gem.add_runtime_dependency "delayed_job",     ["> 2.0.3"]
 


### PR DESCRIPTION
https://github.com/ejschmitt/delayed_job_web/pull/103  introduced a major version upgrade for `sinatra` from `v1.4.4` to `v2.0.1`. Unfortunately, this doesn't allow us to continue using `delayed_job_web` in old projects, that depend on `sinatra 1.x` (we have to bump `delayed_job_web` to eliminate latest CVEs).

The original CVE fix (https://github.com/sinatra/sinatra/pull/1379) was introduced for `sinatra 2.x` only, but it was also backported to the `rack-protection` gem, which is used in `sinatra 1.x`: https://github.com/sinatra/rack-protection/pull/120 Also, see https://github.com/rubysec/ruby-advisory-db/pull/331

So, I think, we should revert changes introduced in https://github.com/ejschmitt/delayed_job_web/pull/103 and instead explicitly require the latest version of `rack-protection` to address CVE. This will allow us to use the latest (and the safest) version of `delayed_job_web` in both old and new projects.

BTW, are you guys following https://semver.org? It was pretty surprising to see, that **patch** (1.4.1) introduced a **major** dependency upgrade :)