### PR TITLE
Adding the ability to view jobs by priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.4.5] - 2019-03-07
+  - Bumping Sinatra to 1.4.8 to address Fixnum warnings
+
+## [1.4.4] - 2018-09-14
+  - Adding the ability to view jobs by priority
+
 ## [1.4.3] - 2018-06-11
 
 ### Fixed

--- a/delayed_job_web.gemspec
+++ b/delayed_job_web.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name        = "delayed_job_web"
-  gem.version     = "1.4.4"
+  gem.version     = "1.4.5"
   gem.author      = "Erick Schmitt"
   gem.email       = "ejschmitt@gmail.com"
   gem.homepage    = "https://github.com/ejschmitt/delayed_job_web"
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
     "README.markdown"
   ]
 
-  gem.add_runtime_dependency "sinatra",         [">= 1.4.4"]
+  gem.add_runtime_dependency "sinatra",         [">= 1.4.8"]
   gem.add_runtime_dependency "rack-protection", [">= 1.5.5"]
   gem.add_runtime_dependency "activerecord",    ["> 3.0.0"]
   gem.add_runtime_dependency "delayed_job",     ["> 2.0.3"]

--- a/delayed_job_web.gemspec
+++ b/delayed_job_web.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name        = "delayed_job_web"
-  gem.version     = "1.4.3"
+  gem.version     = "1.4.4"
   gem.author      = "Erick Schmitt"
   gem.email       = "ejschmitt@gmail.com"
   gem.homepage    = "https://github.com/ejschmitt/delayed_job_web"

--- a/lib/delayed_job_web/application/app.rb
+++ b/lib/delayed_job_web/application/app.rb
@@ -57,6 +57,10 @@ class DelayedJobWeb < Sinatra::Base
     end
   end
 
+  def priority_path(priority)
+    url_path(['priority', priority])
+  end
+
   def with_queue(queue, &block)
     aux_queues = @queues
     @queues = Array(queue)
@@ -200,6 +204,13 @@ class DelayedJobWeb < Sinatra::Base
     get "/#{page}/:id.poll" do
       show_for_polling(page)
     end
+  end
+
+  get '/priority/:priority' do
+    @jobs = delayed_job.where(priority: params[:priority]).order('id desc').offset(start).limit(per_page)
+    @all_jobs = delayed_job
+
+    erb :priority
   end
 
   def poll

--- a/lib/delayed_job_web/application/app.rb
+++ b/lib/delayed_job_web/application/app.rb
@@ -150,13 +150,13 @@ class DelayedJobWeb < Sinatra::Base
 
   post "/requeue/:id" do
     job = delayed_job.find(params[:id])
-    job.update_attributes(:run_at => Time.now, :failed_at => nil)
+    job.update(:run_at => Time.now, :failed_at => nil)
     redirect back
   end
 
   post "/reload/:id" do
     job = delayed_job.find(params[:id])
-    job.update_attributes(:run_at => Time.now, :failed_at => nil, :locked_by => nil, :locked_at => nil, :last_error => nil, :attempts => 0)
+    job.update(:run_at => Time.now, :failed_at => nil, :locked_by => nil, :locked_at => nil, :last_error => nil, :attempts => 0)
     redirect back
   end
 
@@ -208,7 +208,7 @@ class DelayedJobWeb < Sinatra::Base
 
   get '/priority/:priority' do
     @jobs = delayed_job.where(priority: params[:priority]).order('id desc').offset(start).limit(per_page)
-    @all_jobs = delayed_job
+    @all_jobs = delayed_job.where(priority: params[:priority])
 
     erb :priority
   end

--- a/lib/delayed_job_web/application/views/layout.erb
+++ b/lib/delayed_job_web/application/views/layout.erb
@@ -2,8 +2,8 @@
 <html>
   <head>
     <title>Delayed Job Web</title>
-    <link rel="stylesheet" type="text/css" href="stylesheets/reset.css" />
-    <link rel="stylesheet" type="text/css" href="stylesheets/style.css" />
+    <link rel="stylesheet" type="text/css" href=<%= u("stylesheets/reset.css") %> />
+    <link rel="stylesheet" type="text/css" href=<%= u("stylesheets/style.css") %> />
   </head>
   <body>
     <div class="header">

--- a/lib/delayed_job_web/application/views/layout.erb
+++ b/lib/delayed_job_web/application/views/layout.erb
@@ -2,8 +2,142 @@
 <html>
   <head>
     <title>Delayed Job Web</title>
-    <link rel="stylesheet" type="text/css" href=<%= u("stylesheets/reset.css") %> />
-    <link rel="stylesheet" type="text/css" href=<%= u("stylesheets/style.css") %> />
+    <style>
+      html, body, div, span, applet, object, iframe,
+      h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+      a, abbr, acronym, address, big, cite, code,
+      del, dfn, em, font, img, ins, kbd, q, s, samp,
+      small, strike, strong, sub, sup, tt, var,
+      dl, dt, dd, ul, li,
+      form, label, legend,
+      table, caption, tbody, tfoot, thead, tr, th, td {
+      	margin: 0;
+      	padding: 0;
+      	border: 0;
+      	outline: 0;
+      	font-weight: inherit;
+      	font-style: normal;
+      	font-size: 100%;
+      	font-family: inherit;
+      }
+
+      body {
+      	line-height: 1;
+      }
+
+      ul {
+      	list-style: none;
+      }
+
+      table {
+      	border-collapse: collapse;
+      	border-spacing: 0;
+      }
+
+      caption, th, td {
+      	text-align: left;
+      	font-weight: normal;
+      }
+
+      blockquote:before, blockquote:after,
+      q:before, q:after {
+      	content: "";
+      }
+
+      blockquote, q {
+      	quotes: "" "";
+      }
+      html { background:#efefef; font-family:Arial, Verdana, sans-serif; font-size:13px; }
+      body { padding:0; margin:0; }
+      pre { font-family:Courier New; line-height:1.4em; }
+
+      .hide { display:none; }
+
+      .header { background:#000; padding:8px 5% 0 5%; border-bottom:1px solid #444;border-bottom:5px solid #3B5998;}
+      .header h1 { color:#333; font-size:90%; font-weight:bold; margin-bottom:6px;}
+      .header ul li { display:inline;}
+      .header ul li a { color:#fff; text-decoration:none; margin-right:10px; display:inline-block;  padding:8px; -webkit-border-top-right-radius:6px; -webkit-border-top-left-radius:6px; -moz-border-radius-topleft:6px; -moz-border-radius-topright:6px; }
+      .header ul li a:hover { background:#333;}
+      .header ul li.current a { background:#3B5998; font-weight:bold; color:#fff;}
+
+      .header .namespace { position: absolute; right: 75px; top: 10px; color: #7A7A7A; }
+
+      .subnav { padding:2px 5% 7px 5%; background:#3B5998; font-size:90%;}
+      .subnav li { display:inline;}
+      .subnav li a { color:#fff; text-decoration:none; margin-right:10px; display:inline-block; background:#dd5b5b; padding:5px; -webkit-border-radius:3px; -moz-border-radius:3px;}
+      .subnav li.current a { background:#fff; font-weight:bold; color:#3B5998;}
+      .subnav li a:active { background:#b00909;}
+
+      #main { padding:10px 5%; background:#fff; overflow:hidden; }
+      #main .logo { float:right; margin:10px;}
+      #main span.hl { background:#efefef; padding:2px;}
+      #main h1 { margin:10px 0; font-size:190%; font-weight:bold; color:#3B5998;}
+      #main h2 { margin:10px 0; font-size:130%;}
+      #main table { width:100%; margin:10px 0;}
+      #main table tr td, #main table tr th { border:1px solid #ccc; padding:6px;}
+      #main table tr th { background:#efefef; color:#888; font-size:80%; font-weight:bold;}
+      #main table tr td.no-data { text-align:center; padding:40px 0; color:#999; font-style:italic; font-size:130%;}
+      #main a { color:#111;}
+      #main p { margin:5px 0;}
+      #main p.intro { margin-bottom:15px; font-size:85%; color:#999; margin-top:0; line-height:1.3;}
+      #main h1.wi { margin-bottom:5px;}
+      #main p.sub { font-size:95%; color:#999;}
+
+      #main table.overview { width:40%;}
+      #main table.overview td.status { font-weight:bold; width:50%;}
+      #main table.overview tr.failed td { border-top:2px solid; font-size:90%; }
+      #main table.overview tr.failure td { background:#ffecec; border-top:2px solid #d37474; font-size:90%; color:#d37474;}
+      #main table.overview tr.failure td a{ color:#d37474;}
+
+      #main table.jobs td.class { font-family:Monaco, "Courier New", monospace; font-size:90%; width:50%;}
+      #main table.jobs td.args{ width:50%;}
+
+      #main table.workers td.icon {width:1%; background:#efefef;text-align:center;}
+      #main table.workers td.icon img { height: 16px; width: 16px; }
+      #main table.workers td.where { width:25%;}
+      #main table.workers td.queues { width:35%;}
+      #main .queue-tag { background:#b1d2e9; padding:2px; margin:0 3px; font-size:80%; text-decoration:none; text-transform:uppercase; font-weight:bold; color:#3274a2; -webkit-border-radius:4px; -moz-border-radius:4px;}
+      #main table.workers td.queues.queue { width:10%;}
+      #main table.workers td.process { width:35%;}
+      #main table.workers td.process span.waiting { color:#999; font-size:90%;}
+      #main table.workers td.process small { font-size:80%; margin-left:5px;}
+      #main table.workers td.process code { font-family:Monaco, "Courier New", monospace; font-size:90%;}
+      #main table.workers td.process small a { color:#999;}
+      #main.polling table.workers tr.working td { background:#f4ffe4; color:#7ac312;}
+      #main.polling table.workers tr.working td.where a { color:#7ac312;}
+      #main.polling table.workers tr.working td.process code { font-weight:bold;}
+
+
+      #main table.stats th { font-size:100%; width:40%; color:#000;}
+      #main hr { border:0; border-top:5px solid #efefef;  margin:15px 0;}
+
+      #footer { padding:10px 5%; background:#efefef; color:#999; font-size:85%; line-height:1.5; border-top:5px solid #ccc; padding-top:10px;}
+      #footer p a { color:#999;}
+
+      #main p.poll { background:url(../images/poll.png) no-repeat 0 2px; padding:3px 0; padding-left:23px; float:right; font-size:85%; }
+
+      #main ul.job {}
+      #main ul.job li {background:-webkit-gradient(linear, left top, left bottom, from(#efefef), to(#fff)) #efefef; margin-top:10px; padding:10px; overflow:hidden; -webkit-border-radius:5px; border:1px solid #ccc; }
+      #main ul.job li dl dt {font-size:80%; color:#999; width:60px; float:left; padding-top:1px; text-align:right;}
+      #main ul.job li dl dd {margin-bottom:10px; margin-left:70px;}
+      #main ul.job li dl dd .retried { float:right; text-align: right; }
+      #main ul.job li dl dd .retried .remove { display:none; margin-top: 8px; }
+      #main ul.job li.hover dl dd .retried .remove { display:block; }
+      #main ul.job li dl dd .controls { display:none; float:right; }
+      #main ul.job li dl dd .controls form { display: inline; }
+      #main ul.job li.hover dl dd .controls { display:block; }
+      #main ul.job li dl dd code, #main ul.failed li dl dd pre { font-family:Monaco, "Courier New", monospace; font-size:90%; white-space: pre-wrap;}
+      #main ul.job li dl dd.error a {font-family:Monaco, "Courier New", monospace; font-size:90%; }
+      #main ul.job li dl dd.error pre { margin-top:3px; line-height:1.3;}
+
+      #main p.pagination { background:#efefef; padding:10px; overflow:hidden;}
+      #main p.pagination a.less { float:left;}
+      #main p.pagination a.more { float:right;}
+
+      #main .header-queues {float:right; margin-top:-10px;margin-left:10px;}
+
+      #main .time a.toggle_format {text-decoration:none;}
+    </style>
   </head>
   <body>
     <div class="header">
@@ -40,8 +174,188 @@
         <a href="https://github.com/ejschmitt/delayed_job_web">delayed_job_web</a>
       </p>
     </div>
-    <script src="<%= u("javascripts/jquery-1.7.1.min.js") %>" type="text/javascript"></script>
-    <script src="<%= u("javascripts/jquery.relatize_date.js") %>" type="text/javascript"></script>
-    <script src="<%= u("javascripts/application.js") %>" type="text/javascript"></script>
+    <script src="https://code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ=" crossorigin="anonymous"></script>
+    <script>
+      $(function() {
+        var poll_interval = 3;
+
+        var relatizer = function(){
+          var dt = $(this).text(), relatized = $.relatizeDate(this)
+          if ($(this).parents("a").length > 0 || $(this).is("a")) {
+            $(this).relatizeDate()
+            if (!$(this).attr('title')) {
+              $(this).attr('title', dt)
+            }
+          } else {
+            $(this)
+            .text('')
+            .append( $('<a href="#" class="toggle_format" title="' + dt + '" />')
+                    .append('<span class="date_time">' + dt +
+                            '</span><span class="relatized_time">' +
+                              relatized + '</span>') )
+          }
+        };
+
+        $('.time').each(relatizer);
+
+        $('.time a.toggle_format .date_time').hide();
+
+        var format_toggler = function(){
+          $('.time a.toggle_format span').toggle();
+          $(this).attr('title', $('span:hidden',this).text());
+          return false;
+        };
+
+        $('.time a.toggle_format').click(format_toggler);
+
+        $('ul li.job').hover(function() {
+          $(this).addClass('hover');
+        }, function() {
+          $(this).removeClass('hover');
+        })
+
+        $('a.backtrace').click(function (e) {
+          e.preventDefault();
+          if($(this).prev('div.backtrace:visible').length > 0) {
+            $(this).next('div.backtrace').show();
+            $(this).prev('div.backtrace').hide();
+          } else {
+            $(this).next('div.backtrace').hide();
+            $(this).prev('div.backtrace').show();
+          }
+        });
+
+        $('a[rel=poll]').click(function(e) {
+          e.preventDefault();
+          var href = $(this).attr('href')
+          $(this).parent().text('Starting...')
+          $("#main").addClass('polling')
+
+          setInterval(function() {
+            $.ajax({dataType: 'text', type: 'get', url: href, success: function(data) {
+              $('#main').html(data);
+            }})
+          }, poll_interval * 1000)
+
+          return false
+        })
+      })
+      // All credit goes to Rick Olson.
+      (function($) {
+        $.fn.relatizeDate = function() {
+          return $(this).each(function() {
+            $(this).text( $.relatizeDate(this) )
+          })
+        }
+
+        $.relatizeDate = function(element) {
+          return $.relatizeDate.timeAgoInWords( new Date($(element).text()) )
+        }
+
+        // shortcut
+        $r = $.relatizeDate
+
+        $.extend($.relatizeDate, {
+          shortDays: [ 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' ],
+          days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+          shortMonths: [ 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' ],
+          months: [ 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December' ],
+
+          /**
+           * Given a formatted string, replace the necessary items and return.
+           * Example: Time.now().strftime("%B %d, %Y") => February 11, 2008
+           * @param {String} format The formatted string used to format the results
+           */
+          strftime: function(date, format) {
+            var day = date.getDay(), month = date.getMonth();
+            var hours = date.getHours(), minutes = date.getMinutes();
+
+            var pad = function(num) {
+              var string = num.toString(10);
+              return new Array((2 - string.length) + 1).join('0') + string
+            };
+
+            return format.replace(/\%([aAbBcdHImMpSwyY])/g, function(part) {
+              switch(part[1]) {
+                case 'a': return $r.shortDays[day]; break;
+                case 'A': return $r.days[day]; break;
+                case 'b': return $r.shortMonths[month]; break;
+                case 'B': return $r.months[month]; break;
+                case 'c': return date.toString(); break;
+                case 'd': return pad(date.getDate()); break;
+                case 'H': return pad(hours); break;
+                case 'I': return pad((hours + 12) % 12); break;
+                case 'm': return pad(month + 1); break;
+                case 'M': return pad(minutes); break;
+                case 'p': return hours > 12 ? 'PM' : 'AM'; break;
+                case 'S': return pad(date.getSeconds()); break;
+                case 'w': return day; break;
+                case 'y': return pad(date.getFullYear() % 100); break;
+                case 'Y': return date.getFullYear().toString(); break;
+              }
+            })
+          },
+
+          timeAgoInWords: function(targetDate, includeTime) {
+            return $r.distanceOfTimeInWords(targetDate, new Date(), includeTime);
+          },
+
+          /**
+           * Return the distance of time in words between two Date's
+           * Example: '5 days ago', 'about an hour ago'
+           * @param {Date} fromTime The start date to use in the calculation
+           * @param {Date} toTime The end date to use in the calculation
+           * @param {Boolean} Include the time in the output
+           */
+          distanceOfTimeInWords: function(fromTime, toTime, includeTime) {
+            var delta = parseInt((toTime.getTime() - fromTime.getTime()) / 1000);
+            if (delta < (-(48*60*60) - 1)) {
+                var daysfrom = parseInt(Math.abs(delta / 86400));
+                if (daysfrom > 5) {
+                    var fmt = '%B %d, %Y';
+                    if (includeTime) fmt += ' %I:%M %p';
+                    return $r.strftime(fromTime, fmt);
+                } else {
+                    return daysfrom + " days from now";
+                }
+            } else if (delta < -(48*60*60)) {
+                return '2 days from now';
+            } else if (delta < -(24*60*60)) {
+                return '1 day from now';
+            } else if (delta < -(120*60)) {
+                return 'about ' + parseInt(Math.abs(delta / 3600)).toString() +
+                    ' hours from now';
+            } else if (delta < -(45*60)) {
+                return 'about an hour from now';
+            } else if (delta < -60) {
+                return parseInt(Math.abs(delta / 60)).toString()
+                    + ' minutes from now';
+            } else if (delta < 0) {
+                return 'less than a minute from now';
+            } else if (delta < 60) {
+                return 'less than a minute ago';
+            } else if (delta < 120) {
+                return 'about a minute ago';
+            } else if (delta < (45*60)) {
+                return (parseInt(delta / 60)).toString() + ' minutes ago';
+            } else if (delta < (120*60)) {
+                return 'about an hour ago';
+            } else if (delta < (24*60*60)) {
+                return 'about ' + (parseInt(delta / 3600)).toString() + ' hours ago';
+            } else if (delta < (48*60*60)) {
+                return '1 day ago';
+              var days = (parseInt(delta / 86400)).toString();
+              if (days > 5) {
+                var fmt  = '%B %d, %Y'
+                if (includeTime) fmt += ' %I:%M %p'
+                return $r.strftime(fromTime, fmt);
+              } else {
+                return days + " days ago"
+              }
+            }
+          }
+        })
+      })(jQuery);
+    </script>
   </body>
 </html>

--- a/lib/delayed_job_web/application/views/overview.erb
+++ b/lib/delayed_job_web/application/views/overview.erb
@@ -63,4 +63,24 @@
   <% end %>
 </table>
 
+<table class="overview">
+  <tr>
+    <th>Priority</th>
+    <th>Count</th>
+  </tr>
+
+  <% delayed_jobs(nil).group(:priority).size.each do |priority, count| %>
+    <tr>
+      <td class="status">
+        <a href="<%= priority_path(priority) %>">
+          <%= priority %>
+        </a>
+      </td>
+      <td>
+      <%= count %>
+      </td>
+    </tr>
+  <% end %>
+</table>
+
 <%= poll %>

--- a/lib/delayed_job_web/application/views/priority.erb
+++ b/lib/delayed_job_web/application/views/priority.erb
@@ -1,0 +1,13 @@
+<h1>Priority <%= params[:priority] %> Jobs</h1>
+<p class="sub">
+  The list below contains all priority <%= params[:priority] %> jobs currently in the delayed_job queue.
+</p>
+<p class="sub">
+  <%= "Showing #{start} to #{start + per_page} of #{@all_jobs.count} enqueued jobs." %>
+</p>
+<ul class="job">
+  <% @jobs.each do |job| %>
+    <%= partial :job, {:job => job} %>
+  <% end %>
+</ul>
+<%= partial :next_more, :start => start, :total_size => @all_jobs.count, :per_page => per_page %>

--- a/test/integration/test_mounted_in_rails_app.rb
+++ b/test/integration/test_mounted_in_rails_app.rb
@@ -16,4 +16,11 @@ class TestMountedInRailsApp < MiniTest::Unit::TestCase
       assert last_response.ok?, "Received bad response: #{last_response.inspect}"
     end
   end
+
+  def test_priority
+    get '/delayed_job/priority/0'
+
+    assert last_response.ok?, "Received bad response: #{last_response.inspect}"
+  end
+
 end

--- a/test/lib/delayed_job_web/application/test_app.rb
+++ b/test/lib/delayed_job_web/application/test_app.rb
@@ -75,7 +75,7 @@ class TestDelayedJobWeb < MiniTest::Unit::TestCase
 
   def test_requeue_id
     job = Minitest::Mock.new
-    job.expect(:update_attributes, nil, [:run_at => time, :failed_at => nil])
+    job.expect(:update, nil, [:run_at => time, :failed_at => nil])
 
     find = lambda { | id |
       id.must_equal "1"


### PR DESCRIPTION
We use priorities instead of queues to manage our jobs so needed a way to quickly see this. To that end this PR has:
- Added a table to overview that shows the different job priorities and count
- Added the ability to view jobs by priority