### PR TITLE
Add basic filtering for job attributes in the UI.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -114,6 +114,10 @@ DelayedJobWeb.set(:allow_requeue_pending, false)
 
   Controls whether the 'Enqueue all immediately' button is available on the list of Pending jobs. Hiding this button can be useful if you have jobs set to run in the future and you don't want to accidentally run them immediately.
 
+* **`filtered_job_attributes`** (default: `[]`)
+
+  Lets you set parts of the job handler job_data that can be filtered. eg. setting this to ["arguments"], removes the job arguments from the UI.
+
 
 Contributing
 ------------

--- a/lib/delayed_job_web/application/app.rb
+++ b/lib/delayed_job_web/application/app.rb
@@ -10,6 +10,7 @@ class DelayedJobWeb < Sinatra::Base
   set :views, File.expand_path('../views', __FILE__)
 
   set :allow_requeue_pending, true
+  set :filtered_job_attributes, []
 
   # Enable sessions so we can use CSRF protection
   enable :sessions
@@ -29,6 +30,7 @@ class DelayedJobWeb < Sinatra::Base
 
   before do
     @queues = (params[:queues] || "").split(",").map{|queue| queue.strip}.uniq.compact
+    @filtered_job_attributes = settings.filtered_job_attributes
   end
 
   def current_page

--- a/lib/delayed_job_web/application/views/job.erb
+++ b/lib/delayed_job_web/application/views/job.erb
@@ -22,7 +22,15 @@
     <% end %>
     <dt>Handler</dt>
     <dd>
-    <pre><%=h job.handler %></pre>
+    <pre>
+      <% if @filtered_job_attributes.empty? %>
+        <%=h job.handler %>
+      <% else %>
+        <% job_wrapper = YAML.load_dj(job.handler) %>
+        <% @filtered_job_attributes.each { |key| job_wrapper.job_data.delete(key) } %>
+        <%=h job_wrapper.to_yaml %></pre>
+      <% end %>
+    </pre>
     </dd>
     <% if job.last_error %>
       <dt>Last Error</dt>


### PR DESCRIPTION
Can be used used to hide potentially sensitive arguments.