### PR TITLE
Use Rails environment in /stats

### DIFF
--- a/lib/delayed_job_web/application/views/stats.erb
+++ b/lib/delayed_job_web/application/views/stats.erb
@@ -5,7 +5,7 @@
       environment
     </th>
     <th>
-      <%=h Sinatra::Application.environment.to_s %>
+      <%=h Rails.env.to_s %>
     </th>
   </tr>
   <tr>


### PR DESCRIPTION
Use the `Rails.env` instead of `Sinatra::Application.environment`.

Sinatra depends on `APP_ENV` rather than `RAILS_ENV` and defaults to
`development` if no `APP_ENV` is set. This can lead to situations where
the host application is running in `production` but the dashboard is
showing `development`.

Fixes #112

```
$ bin/www
=> Booting Puma
=> Rails 5.2.3 application starting in production
=> Run `rails server -h` for more startup options
Puma starting in single mode...
* Version 3.12.0 (ruby 2.5.1-p57), codename: Llamas in Pajamas
* Min threads: 5, max threads: 5
* Environment: production
* Listening on tcp://0.0.0.0:8082
Use Ctrl-C to stop
```

<img width="1326" alt="Screenshot 2019-12-13 20 11 31" src="https://user-images.githubusercontent.com/205556/70841100-81c35580-1de5-11ea-9f81-455b4640679e.png">
