### PR TITLE
update requeue and reload to use update instead of update_attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.4.4] - 2020-02-01
+
+### Fixed
+
+  - atstockland updated requeue and reload to use update method instead of deprecated update_attributes.
+
 ## [1.4.3] - 2018-06-11
 
 ### Fixed

--- a/delayed_job_web.gemspec
+++ b/delayed_job_web.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name        = "delayed_job_web"
-  gem.version     = "1.4.3"
+  gem.version     = "1.4.4"
   gem.author      = "Erick Schmitt"
   gem.email       = "ejschmitt@gmail.com"
   gem.homepage    = "https://github.com/ejschmitt/delayed_job_web"

--- a/lib/delayed_job_web/application/app.rb
+++ b/lib/delayed_job_web/application/app.rb
@@ -146,13 +146,13 @@ class DelayedJobWeb < Sinatra::Base
 
   post "/requeue/:id" do
     job = delayed_job.find(params[:id])
-    job.update_attributes(:run_at => Time.now, :failed_at => nil)
+    job.update(run_at: Time.now, failed_at: nil)
     redirect back
   end
 
   post "/reload/:id" do
     job = delayed_job.find(params[:id])
-    job.update_attributes(:run_at => Time.now, :failed_at => nil, :locked_by => nil, :locked_at => nil, :last_error => nil, :attempts => 0)
+    job.update(run_at: Time.now, failed_at: nil, locked_by: nil, locked_at: nil, last_error: nil, attempts: 0)
     redirect back
   end
 
@@ -192,7 +192,7 @@ class DelayedJobWeb < Sinatra::Base
     @partial = false
   end
 
-  %w(overview enqueued working pending failed stats) .each do |page|
+  %w[overview enqueued working pending failed stats].each do |page|
     get "/#{page}.poll" do
       show_for_polling(page)
     end


### PR DESCRIPTION
update_attributes is deprecated in Rails 6 and is causing error when attempting to retry or reload a job.  Simply changing update_attributes to update fixes these issues.  This fork is being used in my production app and working like the old days.