### PR TITLE
Add confirmation message when clearing jobs

### DIFF
--- a/lib/delayed_job_web/application/views/failed.erb
+++ b/lib/delayed_job_web/application/views/failed.erb
@@ -1,6 +1,6 @@
 <h1>Failed Jobs</h1>
 <% if @jobs.any? %>
-  <form action="<%= u('failed/clear') %>" method="POST">
+  <form action="<%= u('failed/clear') %>" method="POST" onsubmit="return confirm('Are you sure you want to clear all failed jobs?');">
     <%= csrf_token_tag %>
     <input type="submit" value="Clear Failed Jobs"></input>
   </form>


### PR DESCRIPTION
I accidentally clicked on 'Clear failed jobs' today when I meant to retry, not a great situation.
This PR adds a confirmation message since Clearing is a destructive action.