### PR TITLE
Disable host authorization in dev mode

### DIFF
--- a/lib/delayed_job_web/application/app.rb
+++ b/lib/delayed_job_web/application/app.rb
@@ -27,6 +27,11 @@ class DelayedJobWeb < Sinatra::Base
     # Deny the request, don't clear the session
     :reaction => :deny
 
+  configure :development do
+    # Allow any host in development mode
+    set :host_authorization, { permitted_hosts: [] }
+  end
+
   before do
     @queues = (params[:queues] || "").split(",").map{|queue| queue.strip}.uniq.compact
   end


### PR DESCRIPTION
### What

Disable host authorization in development mode by setting `permitted_hosts` to an empty array.

In other words - this change allows any host to be used in development.

### Why

Sinatra v4.1.0 added a new `host_authorization` setting, which by default restricts development hosts to `.localhost` and `.test`. This does not work for everyone!

For those of us not using one of these default hosts in development mode, loading the web dash results in a 403 "Host not permitted" error. This change resolves that problem.

* [Relevant sinatra release notes](https://github.com/sinatra/sinatra/blob/main/CHANGELOG.md#410--2024-11-18)
* https://github.com/sinatra/sinatra/pull/2053